### PR TITLE
SNOW-2146084: Append references to errata

### DIFF
--- a/oval/transform.py
+++ b/oval/transform.py
@@ -92,6 +92,18 @@ def references( cves, fixes, impact, public ) :
     references = [ ]
     for cve in cves :
         cve_id = cve[ 'name' ]
+        references.append(
+            { 
+                'id'      : cve_id, 
+                'url'     : cve[ 'sourceLink' ],
+                'source'  : cve[ 'sourceBy' ],
+                'cvss3'   : cve[ 'cvss3BaseScore' ] + cve[ 'cvss3ScoringVector' ],
+                'cwe'     : cve[ 'cwe' ],
+                'impact'  : impact,
+                'public'  : public,
+                'cve'     : cve_id
+            }
+        )
 
         # lookup bug for this cve (could be more efficient)
         for bug in bugs :
@@ -148,9 +160,10 @@ def definitions( advisories, rl_version ) :
         # create references
         refs = references( advisory[ 'cves' ], advisory[ 'fixes' ], severity.lower( ), issued.replace( '-', '' ) )
         for reference in refs :
-            id = reference[ 'bugdesc' ].split( ' ' )[ 0 ]
-            desc = reference[ 'bugdesc' ].replace( id, '' )
-            description = description + '*' + desc + '. (' + id + ')\n\n'
+            if 'bugdesc' in reference:
+                id = reference[ 'bugdesc' ].split( ' ' )[ 0 ]
+                desc = reference[ 'bugdesc' ].replace( id, '' )
+                description = description + '*' + desc + '. (' + id + ')\n\n'
 
         # create definition
         definitions.append( 

--- a/oval/xml.py
+++ b/oval/xml.py
@@ -159,9 +159,10 @@ def metadata( title, family, platforms, ref_id, source, references, description,
                '" impact="' + reference[ 'impact' ] + '" public="' + \
                reference[ 'public' ] + '">' + reference[ 'cve' ] + '</cve>\n'
 
-        bugs = bugs + \
-               '      <bugzilla href="' + reference[ 'bugref' ] + '" id="' + \
-               reference[ 'bugid' ] + '">' + reference[ 'bugdesc' ] + '</bugzilla>\n'
+        if 'bugref' in reference:
+            bugs = bugs + \
+                '      <bugzilla href="' + reference[ 'bugref' ] + '" id="' + \
+                reference[ 'bugid' ] + '">' + reference[ 'bugdesc' ] + '</bugzilla>\n'
 
     xml = xml + \
           cves + \


### PR DESCRIPTION
## Summary
We want to add rocky 8 errata to the vulnerability db. Currently the errata from upstream is not populated regularly and doesn't contains all the data that we need. In this PR we are appending the references without the bug info (as something changed in the data source of those files and those are not populated the way code assumes). 

## Test plan
I regenerated the errata and checked that it contains the references informations like:
```
 <reference ref_id="RLSA-2024:5312" ref_url="https://errata.rockylinux.org/RLSA-2024:5312" source="RLSA"/>
``` 
and the `cve` informations:
```
<cve cvss3="7.5CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N" cwe="UNKNOWN" href="https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-37370" impact="moderate" public="20250507">CVE-2024-37370</cve>
```
