### PR TITLE
SNOW-2146084: Fix starting page in scanning advisories

### DIFF
--- a/oval/control.py
+++ b/oval/control.py
@@ -39,7 +39,7 @@ def ingest( rl_version ) :
     """
 
     alist = []
-    page = 1
+    page = 0
     while True:
         product_filter = f"&filters.product=Rocky%20Linux%20{rl_version}"
         url = f"{BASEAPI}{BASEFILTER}{product_filter}&page={page}&limit={PER_RQ_LIMIT}"


### PR DESCRIPTION
The scanning should start from the first page, so I changed the starting page from 1 to 0 in the `ingest` method in the `oval/control.py` file.