### PR TITLE
SNOW-0000: Add perl-DBI to allowed modularity labels

### DIFF
--- a/oval/modularity_labels.py
+++ b/oval/modularity_labels.py
@@ -24,6 +24,7 @@ ALLOWED_MODULARITY_LABELS = {
   "pam",
   "parfait",
   "perl-App-cpanminus",
+  "perl-DBI",
   "perl-FCGI",
   "perl",
   "php",


### PR DESCRIPTION
## Summary
- Add `perl-DBI` to `ALLOWED_MODULARITY_LABELS` so Rocky Linux 8 RLSA advisories for the perl-DBI AppStream module can be converted to OVAL XML.
- Unblocks `snowgrype-vulnerability-db-build`, which currently fails with:
  `AssertionError: Not supported modularity labels: ['perl-DBI']`
## Test plan
- [ ] `docker run oval_container 8 > org.rockylinux.rlsa-8.xml` succeeds in prodsec-crons vulnerability-db build
- [ ] After merging, bump `oval` submodule in `snowflake-eng/prodsec-crons` and re-run Jenkins